### PR TITLE
Add support for nested selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ let css = Stylesheet {
             BackgroundColor(.red)
             Color(.white)
             TextAlign(.left)
+	         Element(.p) {
+                FontWeight(.bold)
+	         }
         }
         .pseudo(.nthChild(2))
     }

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ let css = Stylesheet {
             BackgroundColor(.red)
             Color(.white)
             TextAlign(.left)
-	         Element(.p) {
+            Element(.p) {
                 FontWeight(.bold)
-	         }
+            }
         }
         .pseudo(.nthChild(2))
     }

--- a/Sources/SwiftCss/Builders/PropertyBuilder.swift
+++ b/Sources/SwiftCss/Builders/PropertyBuilder.swift
@@ -7,39 +7,39 @@
 
 @resultBuilder
 public enum PropertyBuilder {
-    public static func buildBlock(_ components: Property...) -> [Property] {
+    public static func buildBlock(_ components: SelectorChild...) -> [SelectorChild] {
         components
     }
     
-    public static func buildBlock(_ components: [Property]) -> [Property] {
+    public static func buildBlock(_ components: [SelectorChild]) -> [SelectorChild] {
         components
     }
     
-    public static func buildBlock(_ components: [Property]...) -> [Property] {
+    public static func buildBlock(_ components: [SelectorChild]...) -> [SelectorChild] {
         components.flatMap { $0 }
     }
 
-    public static func buildEither(first component: [Property]) -> [Property] {
+    public static func buildEither(first component: [SelectorChild]) -> [SelectorChild] {
         component
     }
 
-    public static func buildEither(second component: [Property]) -> [Property] {
+    public static func buildEither(second component: [SelectorChild]) -> [SelectorChild] {
         component
     }
 
-    public static func buildOptional(_ component: [Property]?) -> [Property] {
+    public static func buildOptional(_ component: [SelectorChild]?) -> [SelectorChild] {
         component ?? []
     }
 
-    public static func buildExpression(_ expression: Property) -> [Property] {
+    public static func buildExpression(_ expression: SelectorChild) -> [SelectorChild] {
         [expression]
     }
 
-    public static func buildExpression(_ expression: [Property]) -> [Property] {
+    public static func buildExpression(_ expression: [SelectorChild]) -> [SelectorChild] {
         expression
     }
 
-    public static func buildArray(_ components: [[Property]]) -> [Property] {
+    public static func buildArray(_ components: [[SelectorChild]]) -> [SelectorChild] {
         components.flatMap { $0 }
     }
 }

--- a/Sources/SwiftCss/Components/Property.swift
+++ b/Sources/SwiftCss/Components/Property.swift
@@ -6,7 +6,7 @@
 //
 
 /// https://www.w3schools.com/cssref/
-public struct Property {
+public struct Property: SelectorChild {
     public var name: String
     public var value: String
     var isImportant: Bool = false

--- a/Sources/SwiftCss/Components/Selector+Modifiers.swift
+++ b/Sources/SwiftCss/Components/Selector+Modifiers.swift
@@ -8,6 +8,6 @@
 public extension Selector {
 
     func pseudo(_ pseudo: Pseudo) -> Selector {
-        Selector(name: name, properties: properties, pseudo: pseudo.value)
+        Selector(name: name, children: children, pseudo: pseudo.value)
     }
 }

--- a/Sources/SwiftCss/Components/Selector+Types.swift
+++ b/Sources/SwiftCss/Components/Selector+Types.swift
@@ -5,450 +5,450 @@
 //  Created by Tibor Bodecs on 2021. 07. 10..
 //
 
-public func Root(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Root(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector(":root", builder)
 }
 
-public func All(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func All(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector("*", builder)
 }
 
-public func Element(_ name: HTMLElement, @PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Element(_ name: HTMLElement, @PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector(name.rawValue, builder)
 }
 
-public func Elements(_ names: [HTMLElement], @PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Elements(_ names: [HTMLElement], @PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector(names.map(\.rawValue).joined(separator: ","), builder)
 }
 
-public func Id(_ name: String, @PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Id(_ name: String, @PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector("#" + name, builder)
 }
 
-public func Class(_ name: String, @PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Class(_ name: String, @PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Selector("." + name, builder)
 }
 
-public func Html(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Html(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.html, builder)
 }
 
-public func Body(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Body(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.body, builder)
 }
 
-public func Address(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Address(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.address, builder)
 }
 
-public func Article(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Article(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.article, builder)
 }
 
-public func Aside(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Aside(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.aside, builder)
 }
 
-public func Footer(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Footer(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.footer, builder)
 }
 
-public func Header(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Header(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.header, builder)
 }
 
-public func H1(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H1(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h1, builder)
 }
 
-public func H2(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H2(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h2, builder)
 }
 
-public func H3(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H3(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h3, builder)
 }
 
-public func H4(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H4(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h4, builder)
 }
 
-public func H5(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H5(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h5, builder)
 }
 
-public func H6(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func H6(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.h6, builder)
 }
 
-public func Main(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Main(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.main, builder)
 }
 
-public func Nav(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Nav(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.nav, builder)
 }
 
-public func Section(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Section(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.section, builder)
 }
 
-public func Blockquote(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Blockquote(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.blockquote, builder)
 }
 
-public func Dd(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Dd(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.dd, builder)
 }
 
-public func Div(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Div(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.div, builder)
 }
 
-public func Dl(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Dl(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.dl, builder)
 }
 
-public func Dt(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Dt(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.dt, builder)
 }
 
-public func Figcaption(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Figcaption(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.figcaption, builder)
 }
 
-public func Figure(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Figure(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.figure, builder)
 }
 
-public func Hr(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Hr(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.hr, builder)
 }
 
-public func Li(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Li(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.li, builder)
 }
 
-public func Ol(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Ol(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.ol, builder)
 }
 
-public func P(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func P(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.p, builder)
 }
 
-public func Pre(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Pre(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.pre, builder)
 }
 
-public func Ul(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Ul(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.ul, builder)
 }
 
-public func A(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func A(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.a, builder)
 }
 
-public func Abbr(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Abbr(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.abbr, builder)
 }
 
-public func B(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func B(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.b, builder)
 }
 
-public func Bdi(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Bdi(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.bdi, builder)
 }
 
-public func Bdo(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Bdo(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.bdo, builder)
 }
 
-public func Br(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Br(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.br, builder)
 }
 
-public func Cite(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Cite(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.cite, builder)
 }
 
-public func Code(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Code(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.code, builder)
 }
 
-public func Data(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Data(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.data, builder)
 }
 
-public func Dfn(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Dfn(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.dfn, builder)
 }
 
-public func Em(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Em(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.em, builder)
 }
 
-public func I(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func I(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.i, builder)
 }
 
-public func Kbd(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Kbd(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.kbd, builder)
 }
 
-public func Mark(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Mark(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.mark, builder)
 }
 
-public func Q(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Q(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.q, builder)
 }
 
-public func Ruby(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Ruby(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.ruby, builder)
 }
 
-public func S(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func S(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.s, builder)
 }
 
-public func Samp(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Samp(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.samp, builder)
 }
 
-public func Small(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Small(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.small, builder)
 }
 
-public func Span(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Span(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.span, builder)
 }
 
-public func Strong(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Strong(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.strong, builder)
 }
 
-public func Sub(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Sub(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.sub, builder)
 }
 
-public func Sup(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Sup(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.sup, builder)
 }
 
-public func Time(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Time(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.time, builder)
 }
 
-public func U(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func U(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.u, builder)
 }
 
-public func Var(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Var(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.var, builder)
 }
 
-public func Wbr(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Wbr(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.wbr, builder)
 }
 
-public func Area(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Area(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.area, builder)
 }
 
-public func Audio(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Audio(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.html, builder)
 }
 
-public func Img(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Img(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.img, builder)
 }
 
-public func Map(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Map(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.map, builder)
 }
 
-public func Track(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Track(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.track, builder)
 }
 
-public func Video(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Video(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.video, builder)
 }
 
-public func Embed(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Embed(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.embed, builder)
 }
 
-public func Iframe(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Iframe(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.iframe, builder)
 }
 
-public func Object(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Object(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.object, builder)
 }
 
-public func Param(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Param(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.param, builder)
 }
 
-public func Picture(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Picture(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.picture, builder)
 }
 
-public func Portal(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Portal(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.portal, builder)
 }
 
-public func Source(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Source(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.source, builder)
 }
 
-public func Svg(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Svg(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.svg, builder)
 }
 
-public func Math(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Math(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.math, builder)
 }
 
-public func Canvas(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Canvas(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.canvas, builder)
 }
 
-public func Noscript(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Noscript(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.noscript, builder)
 }
 
-public func Script(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Script(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.script, builder)
 }
 
-public func Del(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Del(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.del, builder)
 }
 
-public func Ins(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Ins(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.ins, builder)
 }
 
-public func Caption(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Caption(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.caption, builder)
 }
 
-public func Col(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Col(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.col, builder)
 }
 
-public func Colgroup(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Colgroup(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.colgroup, builder)
 }
 
-public func Table(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Table(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.table, builder)
 }
 
-public func Tbody(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Tbody(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.tbody, builder)
 }
 
-public func Td(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Td(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.td, builder)
 }
 
-public func Tfoot(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Tfoot(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.tfoot, builder)
 }
 
-public func Th(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Th(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.th, builder)
 }
 
-public func Thead(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Thead(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.thead, builder)
 }
 
-public func Tr(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Tr(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.tr, builder)
 }
 
-public func Button(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Button(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.button, builder)
 }
 
-public func Datalist(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Datalist(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.datalist, builder)
 }
 
-public func Fieldset(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Fieldset(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.fieldset, builder)
 }
 
-public func Form(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Form(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.form, builder)
 }
 
-public func Input(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Input(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.input, builder)
 }
 
-public func Label(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Label(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.label, builder)
 }
 
-public func Legend(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Legend(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.legend, builder)
 }
 
-public func Meter(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Meter(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.meter, builder)
 }
 
-public func Optgroup(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Optgroup(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.optgroup, builder)
 }
 
-public func Option(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Option(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.option, builder)
 }
 
-public func Output(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Output(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.output, builder)
 }
 
-public func Progress(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Progress(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.progress, builder)
 }
 
-public func Select(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Select(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.select, builder)
 }
 
-public func Textarea(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Textarea(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.textarea, builder)
 }
 
-public func Details(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Details(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.details, builder)
 }
 
-public func Dialog(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Dialog(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.dialog, builder)
 }
 
-public func Menu(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Menu(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.menu, builder)
 }
 
-public func Summary(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Summary(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.summary, builder)
 }
 
-public func Slot(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Slot(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.slot, builder)
 }
 
-public func Template(@PropertyBuilder _ builder: () -> [Property]) -> Selector {
+public func Template(@PropertyBuilder _ builder: () -> [SelectorChild]) -> Selector {
     Element(.template, builder)
 }

--- a/Sources/SwiftCss/Components/Selector.swift
+++ b/Sources/SwiftCss/Components/Selector.swift
@@ -6,19 +6,19 @@
 //
 
 /// https://www.w3schools.com/cssref/css_selectors.asp
-public struct Selector {
+public struct Selector: SelectorChild {
     var name: String
-    var properties: [Property]
+    var children: [SelectorChild]
     var pseudo: String? = nil
 
-    public init(name: String, properties: [Property], pseudo: String? = nil) {
+    public init(name: String, children: [SelectorChild], pseudo: String? = nil) {
         self.name = name
-        self.properties = properties
+        self.children = children
         self.pseudo = pseudo
     }
 
-    public init(_ name: String, @PropertyBuilder _ builder: () -> [Property]) {
+    public init(_ name: String, @PropertyBuilder _ builder: () -> [SelectorChild]) {
         self.name = name
-        self.properties = builder()
+        self.children = builder()
     }
 }

--- a/Sources/SwiftCss/Components/SelectorChild.swift
+++ b/Sources/SwiftCss/Components/SelectorChild.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public protocol SelectorChild {}

--- a/Tests/SwiftCssTests/SwiftCssTests.swift
+++ b/Tests/SwiftCssTests/SwiftCssTests.swift
@@ -57,6 +57,12 @@ final class SwiftCssTests: XCTestCase {
             Media(screen: .s) {
                 Class("button") {
                     Color("#cafe00")
+                    Element(.span) {
+                        FontWeight(.bold)
+                        Element(.p) {
+                            Color("#000")
+                        }
+                    }
                 }
             }
             Media(screen: .dark, {
@@ -80,6 +86,12 @@ final class SwiftCssTests: XCTestCase {
                                @media screen and (min-width: 600px) {
                                    .button {
                                        color: #cafe00;
+                                   }
+                                   .button span {
+                                       font-weight: 300;
+                                   }
+                                   .button span p {
+                                       color: #000;
                                    }
                                }
                                @media screen and (prefers-color-scheme: dark) {

--- a/Tests/SwiftCssTests/SwiftCssTests.swift
+++ b/Tests/SwiftCssTests/SwiftCssTests.swift
@@ -88,7 +88,7 @@ final class SwiftCssTests: XCTestCase {
                                        color: #cafe00;
                                    }
                                    .button span {
-                                       font-weight: 300;
+                                       font-weight: bold;
                                    }
                                    .button span p {
                                        color: #000;


### PR DESCRIPTION
Stylesheet languages like [Less](https://lesscss.org) and [Sass](https://sass-lang.com) support nesting declarations, which makes it easier to group all styles for an element and its children into a single block.

This pull request adds the same ability to swift-css, making it possible to (alternatively) write this:

```swift
Class("button") {
    Color("#cafe00")
    Element(.span) {
        FontWeight(.bold)
        Element(.p) {
            Color("#000")
        }
    }
}
```

instead of this:

```swift
Class("button") {
    Color("#cafe00")
}
Selector(".button span") {
    FontWeight(.bold)
}
Selector(".button span p") {
    Color("#000")
}
```
