### PR TITLE
Fix swapped horizontal/vertical padding and margin parameters

### DIFF
--- a/Sources/SwiftCss/Properties/Margin.swift
+++ b/Sources/SwiftCss/Properties/Margin.swift
@@ -42,14 +42,14 @@ public func Margin(_ value: Unit = .zero) -> Property {
     Margin(.length(value))
 }
 
-public func Margin(horizontal: MarginValue = .length(.zero),
-                   vertical: MarginValue = .length(.zero)) -> Property {
-    Margin(horizontal.rawValue + " " + vertical.rawValue)
+public func Margin(vertical: MarginValue = .length(.zero),
+                   horizontal: MarginValue = .length(.zero)) -> Property {
+    Margin(vertical.rawValue + " " + horizontal.rawValue)
 }
 
-public func Margin(horizontal: Unit = .zero,
-                   vertical: Unit = .zero) -> Property {
-    Margin(horizontal: .length(horizontal), vertical: .length(vertical))
+public func Margin(vertical: Unit = .zero,
+                   horizontal: Unit = .zero) -> Property {
+    Margin(vertical: .length(vertical), horizontal: .length(horizontal))
 }
 
 public func Margin(top: MarginValue = .length(.zero),

--- a/Sources/SwiftCss/Properties/Padding.swift
+++ b/Sources/SwiftCss/Properties/Padding.swift
@@ -38,14 +38,14 @@ public func Padding(_ value: Unit = .zero) -> Property {
     Padding(.length(value))
 }
 
-public func Padding(horizontal: PaddingValue = .length(.zero),
-                    vertical: PaddingValue = .length(.zero)) -> Property {
-    Padding(horizontal.rawValue + " " + vertical.rawValue)
+public func Padding(vertical: PaddingValue = .length(.zero),
+                    horizontal: PaddingValue = .length(.zero)) -> Property {
+    Padding(vertical.rawValue + " " + horizontal.rawValue)
 }
 
-public func Padding(horizontal: Unit = .zero,
-                    vertical: Unit = .zero) -> Property {
-    Padding(horizontal: .length(horizontal), vertical: .length(vertical))
+public func Padding(vertical: Unit = .zero,
+                    horizontal: Unit = .zero) -> Property {
+    Padding(vertical: .length(vertical), horizontal: .length(horizontal))
 }
 
 public func Padding(top: PaddingValue = .length(.zero),

--- a/Tests/SwiftCssTests/SelectorTests.swift
+++ b/Tests/SwiftCssTests/SelectorTests.swift
@@ -49,7 +49,7 @@ final class SelectorTests: XCTestCase {
                     Padding(.zero)
                     Padding(.rem(8))
                     Padding(horizontal: .px(8))
-                    Padding(horizontal: .length(.zero), vertical: .inherit)
+                    Padding(vertical: .inherit, horizontal: .length(.zero))
                 }
             }
         }
@@ -58,8 +58,8 @@ final class SelectorTests: XCTestCase {
                                * {
                                    padding: 0;
                                    padding: 8rem;
-                                   padding: 8px 0;
-                                   padding: 0 inherit;
+                                   padding: 0 8px;
+                                   padding: inherit 0;
                                }
                                """#)
     }

--- a/Tests/SwiftCssTests/SwiftCssTests.swift
+++ b/Tests/SwiftCssTests/SwiftCssTests.swift
@@ -15,8 +15,8 @@ final class SwiftCssTests: XCTestCase {
             Charset("UTF-8")
             Media {
                 Root {
-                    Margin(horizontal: .px(8.5), vertical: .px(8))
-                    Padding(horizontal: .px(8), vertical: .px(8))
+                    Margin(vertical: .px(8.5), horizontal: .px(8))
+                    Padding(vertical: .px(8), horizontal: .px(8))
                 }
             }
         }
@@ -28,8 +28,8 @@ final class SwiftCssTests: XCTestCase {
             Charset("UTF-8")
             Media {
                 Root {
-                    Margin(horizontal: .px(8.5), vertical: .px(8))
-                    Padding(horizontal: .px(8), vertical: .px(8))
+                    Margin(vertical: .px(8.5), horizontal: .px(8))
+                    Padding(vertical: .px(8), horizontal: .px(8))
                 }
             }
         }
@@ -49,8 +49,8 @@ final class SwiftCssTests: XCTestCase {
 
             Media {
                 Root {
-                    Margin(horizontal: .px(8.5), vertical: .px(8))
-                    Padding(horizontal: .px(8), vertical: .px(8))
+                    Margin(vertical: .px(8.5), horizontal: .px(8))
+                    Padding(vertical: .px(8), horizontal: .px(8))
                 }
             }
 
@@ -61,7 +61,7 @@ final class SwiftCssTests: XCTestCase {
             }
             Media(screen: .dark, {
                 All {
-                    Margin(horizontal: .px(8), vertical: .px(8))
+                    Margin(vertical: .px(8), horizontal: .px(8))
                 }
             })
             Media(screen: .standalone) {


### PR DESCRIPTION
As per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/margin):

> When **two values** are specified, the first margin applies to the **top and bottom**, the second to the **left and right**.

Top and bottom would be vertical, left and right horizontal.
These parameters are currently swapped in swift-css, so specifying a horizontal value applies it vertically (and vice versa).

This pull request fixes that.